### PR TITLE
feat: add cross-platform support and multi-LLM provider capability to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import (
 func main() {
     // Create an MCP client using stdio
     mcpClient, err := client.NewStdioMCPClient(
-        "./an-mcp-server",  // Path to an MCP server
+        "./an-mcp-server",  // Path to an MCP server executable
         nil,                // Additional environment variables if needed
     )
     if err != nil {
@@ -59,7 +59,7 @@ func main() {
         log.Fatalf("Failed to get tools: %v", err)
     }
 
-    ctx := context.Backgorund()
+    ctx := context.Background()
 
     // Create a Google AI LLM client
     llm, err := googleai.New(
@@ -96,10 +96,17 @@ func main() {
 
 ## Example Applications
 
-See the `example` directory for a complete example:
+See the `example` directory for complete examples:
 
-- `example/agent`: Demonstrates how to use the adapter with an LLM agent
-- `example/server`: A minimal MCP server example
+- `example/agent`: Demonstrates how to use the adapter with various LLM providers (Google AI, OpenAI, Anthropic)
+- `example/server`: A minimal MCP server example that provides a URL fetching tool
+
+The example agent supports multiple LLM providers:
+- **Google AI (Gemini)**: Set `GOOGLE_API_KEY`
+- **OpenAI**: Set `OPENAI_API_KEY`
+- **Anthropic (Claude)**: Set `ANTHROPIC_API_KEY`
+
+The example is cross-platform and works on Windows, macOS, and Linux. The example automatically builds and runs the MCP server from source. See the [example README](./example/agent/README.md) for detailed setup instructions.
 
 The mcp-curl server in this sample is based on the code from [this blog](https://k33g.hashnode.dev/creating-an-mcp-server-in-go-and-serving-it-with-docker).
 

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -296,8 +296,8 @@ func TestToolCall(t *testing.T) {
 			toolDesc:       "A test tool",
 			inputSchema:    map[string]any{"param1": map[string]any{"type": "string"}},
 			input:          `invalid json`,
-			expectError:    true,
-			expectedErrMsg: "unmarshal input",
+			expectError:    false,
+			expectedOutput: "call the tool error: input must be valid json, retry tool calling with correct json",
 		},
 		{
 			name:        "tool call error",
@@ -309,8 +309,8 @@ func TestToolCall(t *testing.T) {
 					&mcp.CallToolResult{}, assert.AnError)
 			},
 			input:          `{"param1": "test value"}`,
-			expectError:    true,
-			expectedErrMsg: "call the tool: assert.AnError general error for testing",
+			expectError:    false,
+			expectedOutput: "call the tool error: assert.AnError general error for testing",
 		},
 	}
 

--- a/example/agent/README.md
+++ b/example/agent/README.md
@@ -1,0 +1,59 @@
+# LangChain Go MCP Adapter Example
+
+This example demonstrates how to use the LangChain Go MCP adapter with various LLM providers.
+
+## Prerequisites
+
+Set one of the supported LLM provider API keys:
+- **Google AI (Gemini)**: Set `GOOGLE_API_KEY`
+- **OpenAI**: Set `OPENAI_API_KEY`
+- **Anthropic (Claude)**: Set `ANTHROPIC_API_KEY`
+
+## Running the Example
+
+1. Set your preferred LLM API key:
+   ```bash
+   # For Google AI
+   export GOOGLE_API_KEY="your-api-key"
+   
+   # For OpenAI
+   export OPENAI_API_KEY="your-api-key"
+   
+   # For Anthropic
+   export ANTHROPIC_API_KEY="your-api-key"
+   ```
+
+2. Run the example from this directory:
+   ```bash
+   go run main.go
+   ```
+
+The example will automatically build and start the MCP server from `../server/main.go`.
+
+## How it Works
+
+1. The example automatically builds the MCP server (from `../server/main.go`) as a binary on first run
+   - On Windows, the binary will be named `mcp-server.exe`
+   - On macOS/Linux, it will be named `mcp-server`
+2. The MCP server is started as a subprocess using stdio communication
+3. The MCP adapter connects to this server and discovers available tools (in this case, a `fetch_url` tool)
+4. The discovered tools are combined with built-in LangChain tools (Calculator, Wikipedia)
+5. An agent is created with these tools and processes the user's question
+6. The agent can use the fetch_url tool to retrieve web content and provide summaries
+
+## Cross-Platform Compatibility
+
+This example is designed to work on Windows, macOS, and Linux:
+- The MCP server uses Go's `net/http` package instead of external tools like `curl`
+- Binary names are automatically adjusted for the target OS
+- All file paths use Go's `filepath` package for proper path handling
+
+## Troubleshooting
+
+If you get an LLM error:
+1. Make sure you have set one of the required API keys
+2. Check that your API key is valid
+
+If the MCP server fails to start:
+1. Make sure you have Go installed and in your PATH
+2. Check that the `../server/main.go` file exists

--- a/example/agent/main.go
+++ b/example/agent/main.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
 
 	"github.com/mark3labs/mcp-go/client"
 	"github.com/tmc/langchaingo/agents"
 	"github.com/tmc/langchaingo/chains"
+	"github.com/tmc/langchaingo/llms"
+	"github.com/tmc/langchaingo/llms/anthropic"
 	"github.com/tmc/langchaingo/llms/googleai"
+	"github.com/tmc/langchaingo/llms/openai"
 	langchaingoTools "github.com/tmc/langchaingo/tools"
 	"github.com/tmc/langchaingo/tools/wikipedia"
 
@@ -23,23 +30,23 @@ func main() {
 }
 
 func run() error {
-	llm, err := googleai.New(
-		context.Background(),
-		googleai.WithDefaultModel("gemini-2.0-flash"), // gemini-2.5-pro-exp-03-25"),
-		googleai.WithAPIKey(os.Getenv("GOOGLE_API_KEY")),
-	)
+	// Create LLM based on available API keys
+	llm, err := createLLM()
 	if err != nil {
-		return err
+		return fmt.Errorf("create LLM: %w", err)
 	}
+
 	wp := wikipedia.New("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
 
-	mcpClient, err := client.NewStdioMCPClient("./mcp-curl", nil)
+	// Start the MCP server
+	mcpClient, err := startMCPServer()
 	if err != nil {
 		return fmt.Errorf("create client: %w", err)
 	}
 	defer mcpClient.Close()
 
-	mcpAdapter, err := mcpadapter.New(mcpClient)
+	fmt.Println("Creating MCP adapter...")
+	mcpAdapter, err := mcpadapter.New(mcpClient, mcpadapter.WithToolTimeout(30*time.Second))
 	if err != nil {
 		return fmt.Errorf("new mcp adapter: %w", err)
 	}
@@ -71,4 +78,82 @@ func run() error {
 	fmt.Println("🎉 Answer:", answer)
 
 	return nil
+}
+
+
+// createLLM creates an LLM instance based on available API keys
+func createLLM() (llms.Model, error) {
+	ctx := context.Background()
+
+	// Check for Google AI
+	if apiKey := os.Getenv("GOOGLE_API_KEY"); apiKey != "" {
+		fmt.Println("🤖 Using Google AI (Gemini)")
+		return googleai.New(ctx,
+			googleai.WithDefaultModel("gemini-2.0-flash"),
+			googleai.WithAPIKey(apiKey),
+		)
+	}
+
+	// Check for OpenAI
+	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
+		fmt.Println("🤖 Using OpenAI")
+		return openai.New(
+			openai.WithToken(apiKey),
+			openai.WithModel("gpt-4"),
+		)
+	}
+
+	// Check for Anthropic
+	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
+		fmt.Println("🤖 Using Anthropic (Claude)")
+		return anthropic.New(
+			anthropic.WithToken(apiKey),
+			anthropic.WithModel("claude-3-5-sonnet-20241022"),
+		)
+	}
+
+	return nil, fmt.Errorf("no LLM API key found. Please set one of: GOOGLE_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY")
+}
+
+// getExecutableName returns the executable name with proper extension for the OS
+func getExecutableName(base string) string {
+	if runtime.GOOS == "windows" {
+		return base + ".exe"
+	}
+	return base
+}
+
+// startMCPServer starts the MCP server, building it if necessary.
+// We build and use a binary instead of "go run" because go run can interfere
+// with stdio communication, causing the MCP protocol initialization to hang.
+func startMCPServer() (client.MCPClient, error) {
+	serverDir := "../server"
+	executableName := getExecutableName("mcp-server")
+	serverBinary := filepath.Join(serverDir, executableName)
+	serverSource := filepath.Join(serverDir, "main.go")
+	
+	// Check if binary exists
+	if _, err := os.Stat(serverBinary); os.IsNotExist(err) {
+		fmt.Println("Building MCP server binary...")
+		cmd := exec.Command("go", "build", "-o", executableName, "main.go")
+		cmd.Dir = serverDir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return nil, fmt.Errorf("build server: %w\nOutput: %s", err, output)
+		}
+		fmt.Println("MCP server binary built successfully")
+	}
+	
+	// Use the binary instead of go run to avoid stdio issues
+	fmt.Printf("Starting MCP server from: %s\n", serverBinary)
+	mcpClient, err := client.NewStdioMCPClient(serverBinary, []string{})
+	if err != nil {
+		// If binary fails, try go run as fallback with a warning
+		fmt.Println("Warning: Failed to start binary, trying 'go run' (may hang due to stdio issues)")
+		mcpClient, err = client.NewStdioMCPClient("go", []string{"run", serverSource})
+		if err != nil {
+			return nil, fmt.Errorf("start server: %w", err)
+		}
+	}
+	
+	return mcpClient, nil
 }


### PR DESCRIPTION
## WHAT

  - Removed Windows-only binary, auto-build for all platforms
  - Support Google AI, OpenAI, and Anthropic
  - Replace curl with Go's HTTP client

## WHY

  - Examples now work on Windows, macOS, and Linux
  - Users can choose their preferred LLM provider
  - No external dependencies needed